### PR TITLE
feat: add aria-labels for accessibility to navbar and sidebar links

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -40,6 +40,7 @@ export function Navbar({ pathname }: { pathname: string }) {
                         className="navigation-bar__item"
                         activeClassName="link-active"
                         to="/"
+                        aria-label="Go to homepage"
                         style={{ ...linkStyles, opacity: pathname.includes("/") ? 0.5 : 1, transform: "scale(0.7)" }}
                     >
                         <HomeIcon />

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar({ path }: { path: PageProps["location"]["pathname"] }) {
     return (
         <aside className="sidebar">
             <div>
-                <Link to="/">{path !== "/" ? <HomeIcon /> : null}</Link>
+                <Link to="/" aria-label="Go to homepage">{path !== "/" ? <HomeIcon /> : null}</Link>
                 <button
                     aria-label={isDarkTheme ? "Switch to light theme" : "Switch to dark theme"}
                     onClick={() => {

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -40,7 +40,7 @@ export function Sidebar({ path }: { path: PageProps["location"]["pathname"] }) {
             <div>
                 <Link to="/">{path !== "/" ? <HomeIcon /> : null}</Link>
                 <button
-                    aria-label=""
+                    aria-label={isDarkTheme ? "Switch to light theme" : "Switch to dark theme"}
                     onClick={() => {
                         const html = document.querySelector(":root")
                         if (isDarkTheme) {
@@ -70,6 +70,7 @@ export function Sidebar({ path }: { path: PageProps["location"]["pathname"] }) {
                     target="_blank"
                     href="https://github.com/amanimavu"
                     rel="noopener noreferrer"
+                    aria-label="Visit my Github profile"
                 >
                     <Github />
                 </a>
@@ -79,6 +80,7 @@ export function Sidebar({ path }: { path: PageProps["location"]["pathname"] }) {
                     target="_blank"
                     href="https://www.linkedin.com/in/amani-mavu/"
                     rel="noopener noreferrer"
+                    aria-label="Visit my LinkedIn profile"
                 >
                     <LinkedIn />
                 </a>
@@ -88,6 +90,7 @@ export function Sidebar({ path }: { path: PageProps["location"]["pathname"] }) {
                     target="_blank"
                     href="https://www.instagram.com/it_is_mkongo/"
                     rel="noopener noreferrer"
+                    aria-label="Visit my Instagram profile"
                 >
                     <Instagram />
                 </a>

--- a/src/components/social-bar.tsx
+++ b/src/components/social-bar.tsx
@@ -6,7 +6,13 @@ import { ReactComponent as Instagram } from "images/svgs/instagram-icon.svg"
 export default function SocialBar() {
     return (
         <div id="social-bar">
-            <a className="socials-item" target="_blank" href="https://github.com/amanimavu" rel="noopener noreferrer">
+            <a
+                className="socials-item"
+                target="_blank"
+                href="https://github.com/amanimavu"
+                rel="noopener noreferrer"
+                aria-label="Visit my Github profile"
+            >
                 <Github />
             </a>
 
@@ -15,6 +21,7 @@ export default function SocialBar() {
                 target="_blank"
                 href="https://www.linkedin.com/in/amani-mavu/"
                 rel="noopener noreferrer"
+                aria-label="Visit my LinkedIn profile"
             >
                 <LinkedIn />
             </a>
@@ -24,6 +31,7 @@ export default function SocialBar() {
                 target="_blank"
                 href="https://www.instagram.com/it_is_mkongo/"
                 rel="noopener noreferrer"
+                aria-label="Visit my Instagram profile"
             >
                 <Instagram />
             </a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added ARIA label to the mobile navigation home link for clearer screen reader context
  * Made the theme toggle announce the target theme (e.g., "Switch to light theme"/"Switch to dark theme")
  * Added ARIA labels to social media links across navigation components for improved assistive navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->