### PR TITLE
fix: update mask-url to none for better performance on slow networks

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { StaticImage } from "gatsby-plugin-image"
 import { SEO } from "components/seo"
 import { useCurrentTheme, useNetworkInfo } from "utils/hooks"
 
-import maskPng from "../images/pngs/mask-black.png"
 import maskGif from "../images/gifs/transparent-ink.gif"
 
 export default function Index(props: PageProps) {
@@ -44,7 +43,7 @@ export default function Index(props: PageProps) {
     useEffect(() => {
         const root = document.documentElement
         if (optimizeForSlowNetwork) {
-            root.style.setProperty("--mask-url", `url(${maskPng})`)
+            root.style.setProperty("--mask-url", "none")
         } else {
             root.style.setProperty("--mask-url", `url(${maskGif})`)
         }

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,7 @@
     /* area dimensions */
     --content-height: calc(100vh - (3 * var(--main-padding-y)) - var(--line-height-lg));
 
-    --mask-url: url("../src/images/pngs/mask-black.png");
+    --mask-url: none;
     color-scheme: dark;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed visual mask effects from the landing page. Disabled masking across all network optimization paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->